### PR TITLE
Fix Birdypedia results for Alex Mascarell

### DIFF
--- a/api/collections/variants.js
+++ b/api/collections/variants.js
@@ -16,14 +16,14 @@ class Variants {
         filters[key] = value;
       }
 
+	    if (params.artist) {
+		    filters['credit'] = params.artist;
+	    }
+
       Database.get('variants', filters, {
         select: ['id']
       }).then((variants) => {
         Promise.all(variants.map((variant) => this.get(variant.id, params))).then((variants) => {
-          if (params.artist) {
-            variants = variants.filter((variant) => variant.credit == params.artist);
-          }
-
           resolve(variants);
         });
       });

--- a/api/models/bird.js
+++ b/api/models/bird.js
@@ -34,7 +34,7 @@ class Bird {
             bird: this,
             include: params.include,
             member: params.member,
-		  artist: params.artist
+	    artist: params.artist
           });
 
           this.variants.sort((a, b) => (a.hatched === b.hatched) ? 0 : a.hatched ? -1 : 1);


### PR DESCRIPTION
Fixes a bug where Alex Mascarell would cause the Birdypedia to go into an infinite loop because he's listed as both Alex and Àlex.