### PR TITLE
Exchange bug fixes

### DIFF
--- a/api/models/birdypet.js
+++ b/api/models/birdypet.js
@@ -75,7 +75,7 @@ class BirdyPet {
           await this.bird.fetch(params);
 
           if (params.include?.includes('exchangeData')) {
-            this.exchangeData = await Database.query('SELECT exchanges.id FROM exchange_birdypets JOIN exchanges ON (exchange_birdypets.exchange = exchanges.id) WHERE birdypet = ? AND statusA + statusB BETWEEN 0 AND 3 AND (memberA = ? OR (memberB = ? AND statusB > 0) OR id = ?)', [this.id, this.member, this.member, params.exchange]).then(([data]) => {
+            this.exchangeData = await Database.query('SELECT exchanges.id FROM exchange_birdypets JOIN exchanges ON (exchange_birdypets.exchange = exchanges.id) WHERE birdypet = ? AND (memberA = ? OR (memberB = ? AND statusB > 0) OR id = ?)', [this.id, this.member, this.member, params.exchange]).then(([data]) => {
               if (data) {
                 return data.id;
               } else {

--- a/views/exchange/add.ejs
+++ b/views/exchange/add.ejs
@@ -16,7 +16,7 @@
   <%- include('../scripts/lazyloader.ejs', { template: '../templates/exchange.ejs', paginate: currentPage }) %>
 
   <script type="text/javascript">
-    $('#lazyLoader').on('click', '.card', function (e) {
+    $('#lazyLoader').on('click', '.card:not(.disabled)', function (e) {
       if (e.target.nodeName != 'A') {
         var image = e.currentTarget.querySelector('.birdypet');
         var container = image.parentNode.parentNode;

--- a/views/partials/exchange.ejs
+++ b/views/partials/exchange.ejs
@@ -6,7 +6,6 @@
           <%= exchange.state == 'Completed!' ? 'gave' : 'will give' %>
 
           <% if (exchange.mutable) { %>
-           <% if (member.id == loggedInUser.id) { %>
             <span>
               <select id="<%= side == 'A' ? 'giveA' : 'forB' %>" class="form-select d-inline-block w-auto mt-2">
                <% for (let offer of offers) { %>
@@ -14,9 +13,6 @@
                <% } %>
               </select>
             </span>
-           <% } else { %>
-            <%= exchange[side == 'A' ? 'giveA' : 'forB'] %>
-           <% } %>
           <% } %>
         </h5>
       </div>


### PR DESCRIPTION
Some bug fixes for exchanges.

- Clicking a greyed out bird ("in another exchange") should do nothing, and certainly not cause loading limbo.
- Birds shouldn't show up as greyed out ("in another exchange") when the exchange they were in is done/completed/rescinded/declined.
- Drop downs for "this/any/one" should show up on both sides of the exchange.