### PR TITLE
Session Fix

### DIFF
--- a/helpers/session.js
+++ b/helpers/session.js
@@ -13,6 +13,7 @@ module.exports = session({
     dataset: new Datastore()
   }),
   secret: 'birds are just government drones',
+  key: 'squawk.connect.sid',
   resave: false,
   saveUninitialized: false,
   cookie: {


### PR DESCRIPTION
Attempt to fix the recent issue with some logins not working due to an issue with the `connect.sid` cookie duplicating and the site not knowing which to use. 

Users may be logged out again, but hopefully, logging in will work this time.